### PR TITLE
feat: visible 윈도우에서도 응답 중 아이콘 표시

### DIFF
--- a/scripts/daemon.sh
+++ b/scripts/daemon.sh
@@ -39,13 +39,15 @@ while true; do
     WINDOW_NAME=$(tmux display-message -t "$TARGET" -p '#{window_name}' 2>/dev/null) || continue
     CLEAN_NAME=$(echo "$WINDOW_NAME" | sed "s/^[$ICON_DONE$ICON_RESPONDING] //")
 
-    # User is viewing this window → reset to idle
+    # User is viewing this window → clear done icon, but keep responding icon
     if echo "$VISIBLE" | grep -qF "$TARGET"; then
-      [ "$WINDOW_NAME" != "$CLEAN_NAME" ] && tmux rename-window -t "$TARGET" "$CLEAN_NAME" 2>/dev/null
-      echo "idle" > "$STATE_FILE"
-      echo "0" > "$COUNT_FILE"
-      rm -f "$SNAP_FILE"
-      continue
+      if [ "$STATE" = "done" ]; then
+        [ "$WINDOW_NAME" != "$CLEAN_NAME" ] && tmux rename-window -t "$TARGET" "$CLEAN_NAME" 2>/dev/null
+        echo "idle" > "$STATE_FILE"
+        echo "0" > "$COUNT_FILE"
+        rm -f "$SNAP_FILE"
+        continue
+      fi
     fi
 
     # Compare pane output snapshot


### PR DESCRIPTION
## Summary
- 현재 보고 있는(visible) 윈도우에서도 응답 중(💬) 아이콘이 표시되도록 변경
- 완료(✅) 아이콘만 visible 윈도우에서 자동 제거
- 백그라운드 윈도우 동작은 기존과 동일

## Changes
기존에는 visible 윈도우면 무조건 idle로 리셋하고 `continue`하여 감지 로직을 스킵했다.
변경 후에는 `state=done`일 때만 아이콘 제거 + `continue`하고, 그 외(idle, responding)에는 스냅샷 비교 로직으로 계속 진행한다.

Resolved #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)