### PR TITLE
feat: done 판정 threshold 적용 및 status bar 자동 활성화

### DIFF
--- a/.worklog/feat-3.md
+++ b/.worklog/feat-3.md
@@ -1,0 +1,18 @@
+## done 판정 threshold 적용 및 status bar 자동 활성화
+
+### 핵심 변경 사항
+- done 판정에 threshold 도입: 연속 N회(기본 3회, 1.5초) 출력 미변경 시에만 done(✅) 전환
+  - 기존: 1회 미변경으로 즉시 done → Claude Code가 잠깐 멈추면 💬↔✅ 깜빡임 발생
+  - 개선: 출력 재개 시 done 카운터 즉시 리셋 → 깜빡임 방지
+- `CLAUDE_NOTIFY_DONE_THRESHOLD` 환경변수 추가 (기본값 3)
+- 플러그인 로드 시 `tmux set -g status on` 자동 실행 (status bar 필수이므로)
+- README (영문/한국어) 업데이트
+
+### 설계 결정
+- responding threshold(5)와 동일한 패턴으로 done threshold 구현하여 일관성 유지
+- `status on`은 멱등이라 기존 유저 설정과 충돌 없음
+
+## TODO
+### 검증
+- [ ] 데몬 재시작 후 깜빡임 감소 확인
+- [ ] done threshold 값 튜닝 (3이 적절한지)

--- a/README.ko.md
+++ b/README.ko.md
@@ -21,6 +21,8 @@ tmux에서 Claude Code 응답 상태를 알려주는 플러그인입니다. Clau
 - tmux 3.0+
 - [TPM](https://github.com/tmux-plugins/tpm)
 
+> **참고:** 플러그인 로드 시 tmux 상태바를 자동으로 활성화합니다 (`set -g status on`). 윈도우 이름에 아이콘을 표시하기 위해 필요합니다.
+
 ### TPM으로 설치
 
 `~/.tmux.conf`에 추가:
@@ -51,6 +53,7 @@ run-shell ~/.tmux/plugins/tmux-claude-notify/claude-notify.tmux
 |------|--------|------|
 | `CLAUDE_NOTIFY_INTERVAL` | `0.5` | 폴링 간격 (초) |
 | `CLAUDE_NOTIFY_THRESHOLD` | `5` | 응답 중 판정에 필요한 연속 변경 횟수 |
+| `CLAUDE_NOTIFY_DONE_THRESHOLD` | `3` | 완료 판정에 필요한 연속 미변경 횟수 |
 | `CLAUDE_NOTIFY_ICON_RESPONDING` | `💬` | 응답 중 아이콘 |
 | `CLAUDE_NOTIFY_ICON_DONE` | `✅` | 완료 아이콘 |
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A background daemon polls all tmux panes every 0.5s. It identifies Claude Code p
 - tmux 3.0+
 - [TPM](https://github.com/tmux-plugins/tpm)
 
+> **Note:** The plugin automatically enables the tmux status bar (`set -g status on`) on load, as it's required to display window name icons.
+
 ### With TPM
 
 Add to `~/.tmux.conf`:
@@ -51,6 +53,7 @@ Optional environment variables (set before the plugin loads):
 |----------|---------|-------------|
 | `CLAUDE_NOTIFY_INTERVAL` | `0.5` | Poll interval in seconds |
 | `CLAUDE_NOTIFY_THRESHOLD` | `5` | Consecutive changes needed to detect responding |
+| `CLAUDE_NOTIFY_DONE_THRESHOLD` | `3` | Consecutive unchanged polls needed to detect done |
 | `CLAUDE_NOTIFY_ICON_RESPONDING` | `💬` | Icon for responding state |
 | `CLAUDE_NOTIFY_ICON_DONE` | `✅` | Icon for done state |
 

--- a/claude-notify.tmux
+++ b/claude-notify.tmux
@@ -5,6 +5,9 @@
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DAEMON_SCRIPT="$CURRENT_DIR/scripts/daemon.sh"
 
+# Ensure status bar is enabled (required to see window name icons)
+tmux set -g status on
+
 # Kill existing daemon if running
 pkill -f "claude-notify.*daemon.sh" 2>/dev/null
 

--- a/scripts/daemon.sh
+++ b/scripts/daemon.sh
@@ -8,10 +8,12 @@
 SNAPSHOT_DIR="/tmp/claude-tmux-snapshots"
 STATE_DIR="/tmp/claude-tmux-states"
 COUNTER_DIR="/tmp/claude-tmux-counters"
-mkdir -p "$SNAPSHOT_DIR" "$STATE_DIR" "$COUNTER_DIR"
+DONE_COUNTER_DIR="/tmp/claude-tmux-done-counters"
+mkdir -p "$SNAPSHOT_DIR" "$STATE_DIR" "$COUNTER_DIR" "$DONE_COUNTER_DIR"
 
 POLL_INTERVAL="${CLAUDE_NOTIFY_INTERVAL:-0.5}"
 THRESHOLD="${CLAUDE_NOTIFY_THRESHOLD:-5}"
+DONE_THRESHOLD="${CLAUDE_NOTIFY_DONE_THRESHOLD:-3}"
 ICON_RESPONDING="${CLAUDE_NOTIFY_ICON_RESPONDING:-💬}"
 ICON_DONE="${CLAUDE_NOTIFY_ICON_DONE:-✅}"
 
@@ -33,8 +35,10 @@ while true; do
     SNAP_FILE="$SNAPSHOT_DIR/$PANE_KEY"
     STATE_FILE="$STATE_DIR/$PANE_KEY"
     COUNT_FILE="$COUNTER_DIR/$PANE_KEY"
+    DONE_COUNT_FILE="$DONE_COUNTER_DIR/$PANE_KEY"
     STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "idle")
     COUNT=$(cat "$COUNT_FILE" 2>/dev/null || echo "0")
+    DONE_COUNT=$(cat "$DONE_COUNT_FILE" 2>/dev/null || echo "0")
 
     WINDOW_NAME=$(tmux display-message -t "$TARGET" -p '#{window_name}' 2>/dev/null) || continue
     CLEAN_NAME=$(echo "$WINDOW_NAME" | sed "s/^[$ICON_DONE$ICON_RESPONDING] //")
@@ -45,6 +49,7 @@ while true; do
         [ "$WINDOW_NAME" != "$CLEAN_NAME" ] && tmux rename-window -t "$TARGET" "$CLEAN_NAME" 2>/dev/null
         echo "idle" > "$STATE_FILE"
         echo "0" > "$COUNT_FILE"
+        echo "0" > "$DONE_COUNT_FILE"
         rm -f "$SNAP_FILE"
         continue
       fi
@@ -60,6 +65,7 @@ while true; do
     if [ "$CURRENT" != "$LAST" ]; then
       COUNT=$((COUNT + 1))
       echo "$COUNT" > "$COUNT_FILE"
+      echo "0" > "$DONE_COUNT_FILE"
 
       if [ "$COUNT" -ge "$THRESHOLD" ] && [ "$STATE" != "responding" ]; then
         echo "responding" > "$STATE_FILE"
@@ -67,10 +73,16 @@ while true; do
       fi
     else
       if [ "$STATE" = "responding" ]; then
-        echo "done" > "$STATE_FILE"
-        tmux rename-window -t "$TARGET" "$ICON_DONE $CLEAN_NAME" 2>/dev/null
+        DONE_COUNT=$((DONE_COUNT + 1))
+        echo "$DONE_COUNT" > "$DONE_COUNT_FILE"
+        if [ "$DONE_COUNT" -ge "$DONE_THRESHOLD" ]; then
+          echo "done" > "$STATE_FILE"
+          tmux rename-window -t "$TARGET" "$ICON_DONE $CLEAN_NAME" 2>/dev/null
+          echo "0" > "$COUNT_FILE"
+        fi
+      else
+        echo "0" > "$COUNT_FILE"
       fi
-      echo "0" > "$COUNT_FILE"
     fi
   done
 


### PR DESCRIPTION
## Summary
- done 판정에 threshold 적용 (기본 3회 = 1.5초) → 💬↔✅ 깜빡임 방지
- 플러그인 로드 시 `tmux set -g status on` 자동 실행
- `CLAUDE_NOTIFY_DONE_THRESHOLD` 환경변수 추가

## Test plan
- [ ] 데몬 재시작 후 응답 중 잠깐 멈춤 시 ✅로 전환되지 않는지 확인
- [ ] 응답 완료 후 1.5초 뒤 ✅ 정상 전환 확인
- [ ] status bar off 상태에서 플러그인 로드 시 자동 활성화 확인

Resolved #3