### PR TITLE
docs: 불필요한 TPM 선언 순서 주의사항 제거

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -31,8 +31,6 @@ tmux에서 Claude Code 응답 상태를 알려주는 플러그인입니다. Clau
 set -g @plugin 'devbrother2024/tmux-claude-notify'
 ```
 
-> **중요:** 이 줄은 반드시 `run '~/.tmux/plugins/tpm/tpm'` **앞에** 위치해야 합니다. TPM은 실행 시점 이전에 선언된 플러그인만 인식합니다.
-
 `prefix + I`를 눌러 설치합니다.
 
 ### 수동 설치

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ Add to `~/.tmux.conf`:
 set -g @plugin 'devbrother2024/tmux-claude-notify'
 ```
 
-> **Important:** This line must be placed **before** `run '~/.tmux/plugins/tpm/tpm'`. TPM only recognizes plugins declared before it runs.
-
 Then press `prefix + I` to install.
 
 ### Manual


### PR DESCRIPTION
## Summary
- TPM은 tmux.conf 파일 전체를 파싱하므로 `run` 줄 앞뒤 순서 무관
- 잘못된 주의사항 제거

Resolved #7