### PR TITLE
fix: 완료 아이콘(✅) 소멸 버그 수정

### DIFF
--- a/.worklog/fix-13.md
+++ b/.worklog/fix-13.md
@@ -1,0 +1,15 @@
+## 완료 아이콘 소멸 버그 수정
+
+### 핵심 변경 사항
+- `grep -qF` → `grep -qFx`로 변경하여 윈도우 번호 부분 매칭 버그 수정 (main:1이 main:10에 매칭되던 문제)
+- done 상태의 visible 체크를 CLI 프로세스 체크 앞으로 이동하여, CLI 종료 후에도 done 아이콘 정리 가능
+- sed 이모지 처리를 character class에서 alternation(`($ICON_DONE|$ICON_RESPONDING)`)으로 변경하여 multi-byte 이모지 안정화
+
+### 설계 결정
+- 루프 초반에 state 파일만 읽어서 done 상태를 먼저 확인하고, CLI 프로세스 체크는 그 이후에 수행
+- done 상태 정리에 필요한 변수(WINDOW_NAME, CLEAN_NAME)는 해당 블록 내에서만 계산하여 불필요한 연산 방지
+
+## TODO
+### 검증
+- [ ] tmux 윈도우 10개 이상 환경에서 부분 매칭 버그 재현 불가 확인
+- [ ] CLI 종료 후 done 아이콘이 윈도우 전환 시 정리되는지 확인

--- a/scripts/daemon.sh
+++ b/scripts/daemon.sh
@@ -33,32 +33,33 @@ while true; do
   PS_TREE=$(ps -eo pid,ppid,args 2>/dev/null)
 
   tmux list-panes -a -F '#{session_name}:#{window_index} #{pane_id} #{pane_pid}' 2>/dev/null | while read TARGET PANE_ID PANE_PID; do
+    PANE_KEY=$(echo "$PANE_ID" | tr -d '%')
+    STATE_FILE="$STATE_DIR/$PANE_KEY"
+    STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "idle")
+
+    # User is viewing this window + done state → clear done icon (before CLI check)
+    if [ "$STATE" = "done" ] && echo "$VISIBLE" | grep -qFx "$TARGET"; then
+      WINDOW_NAME=$(tmux display-message -t "$TARGET" -p '#{window_name}' 2>/dev/null) || continue
+      CLEAN_NAME=$(echo "$WINDOW_NAME" | sed -E "s/^($ICON_DONE|$ICON_RESPONDING) //")
+      [ "$WINDOW_NAME" != "$CLEAN_NAME" ] && tmux rename-window -t "$TARGET" "$CLEAN_NAME" 2>/dev/null
+      echo "idle" > "$STATE_FILE"
+      echo "0" > "$COUNTER_DIR/$PANE_KEY"
+      echo "0" > "$DONE_COUNTER_DIR/$PANE_KEY"
+      rm -f "$SNAPSHOT_DIR/$PANE_KEY"
+      continue
+    fi
+
     # Detect AI CLI tools by checking child process args
     echo "$PS_TREE" | awk -v ppid="$PANE_PID" '$2 == ppid' | grep -qE "$CLI_PATTERN" || continue
 
-    PANE_KEY=$(echo "$PANE_ID" | tr -d '%')
     SNAP_FILE="$SNAPSHOT_DIR/$PANE_KEY"
-    STATE_FILE="$STATE_DIR/$PANE_KEY"
     COUNT_FILE="$COUNTER_DIR/$PANE_KEY"
     DONE_COUNT_FILE="$DONE_COUNTER_DIR/$PANE_KEY"
-    STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "idle")
     COUNT=$(cat "$COUNT_FILE" 2>/dev/null || echo "0")
     DONE_COUNT=$(cat "$DONE_COUNT_FILE" 2>/dev/null || echo "0")
 
     WINDOW_NAME=$(tmux display-message -t "$TARGET" -p '#{window_name}' 2>/dev/null) || continue
-    CLEAN_NAME=$(echo "$WINDOW_NAME" | sed "s/^[$ICON_DONE$ICON_RESPONDING] //")
-
-    # User is viewing this window → clear done icon, but keep responding icon
-    if echo "$VISIBLE" | grep -qF "$TARGET"; then
-      if [ "$STATE" = "done" ]; then
-        [ "$WINDOW_NAME" != "$CLEAN_NAME" ] && tmux rename-window -t "$TARGET" "$CLEAN_NAME" 2>/dev/null
-        echo "idle" > "$STATE_FILE"
-        echo "0" > "$COUNT_FILE"
-        echo "0" > "$DONE_COUNT_FILE"
-        rm -f "$SNAP_FILE"
-        continue
-      fi
-    fi
+    CLEAN_NAME=$(echo "$WINDOW_NAME" | sed -E "s/^($ICON_DONE|$ICON_RESPONDING) //")
 
     # Compare pane output snapshot
     CURRENT=$(tmux capture-pane -t "$PANE_ID" -p -S -3 2>/dev/null | eval "$MD5_CMD")


### PR DESCRIPTION
## Summary
- `grep -qF` → `grep -qFx`로 변경하여 윈도우 번호 부분 매칭 버그 수정 (`main:1`이 `main:10`에 매칭되던 문제)
- done 상태 visible 체크를 CLI 프로세스 체크 앞으로 이동하여, CLI 종료 후에도 done 아이콘 정리 가능
- sed 이모지 처리를 character class → alternation으로 변경하여 multi-byte 안정화

## Test plan
- [ ] tmux 윈도우 10개 이상 환경에서 윈도우 1의 ✅ 아이콘이 윈도우 10 전환 시 유지되는지 확인
- [ ] 해당 윈도우로 전환 시 ✅ 아이콘이 정상 제거되는지 확인
- [ ] CLI 종료 후에도 done 아이콘이 윈도우 전환 시 정리되는지 확인

Resolved #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)