### PR TITLE
feat: 권한 요청 대기 상태(waiting) 감지 및 표시 추가

### DIFF
--- a/.worklog/feat-15.md
+++ b/.worklog/feat-15.md
@@ -1,0 +1,18 @@
+## 권한 요청 대기 상태(waiting) 감지 및 표시
+
+### 핵심 변경 사항
+- 새로운 상태 `waiting` 추가 (기본 아이콘: ❓)
+- `responding` 상태에서 출력이 멈춘 후, pane 마지막 10줄에서 권한 요청 패턴(`Do you want to allow`) 감지
+- 패턴 매칭 시 `done`(✅) 대신 `waiting`(❓) 상태로 전환
+- `AGENT_PULSE_ICON_WAITING`, `AGENT_PULSE_WAITING_PATTERN` 환경변수로 커스터마이징 지원
+
+### 설계 결정
+- 감지 범위를 pane 마지막 10줄(`-S -10`)로 설정: 권한 프롬프트가 화면 하단에 표시되므로 충분하며, 성능 영향 최소화
+- `waiting` 상태에서도 출력 변경 감지 시 `responding`로 복귀 (사용자가 승인하면 다시 작업 진행)
+- `waiting` → `idle` 전환도 `done`과 동일하게 사용자가 윈도우를 보면 초기화
+
+## TODO
+### 검증
+- [ ] 실제 Claude Code 권한 요청 시 ❓ 아이콘 표시 확인
+- [ ] 권한 승인 후 💬로 복귀 확인
+- [ ] 데모 GIF 업데이트

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,8 +7,13 @@ tmux에서 AI CLI 도구의 응답 상태를 알려주는 플러그인입니다.
 AI CLI 도구가 동작 중일 때 윈도우 이름에 상태 아이콘을 표시합니다:
 
 - **💬** — AI가 응답 중 (2.5초 이상 출력 감지)
+- **❓** — 사용자 입력 대기 중 (권한 요청 프롬프트 감지)
 - **✅** — AI 응답 완료 (출력 중단)
 - 해당 윈도우로 전환하면 아이콘 자동 제거
+
+## 데모
+
+![tmux-agent-pulse 데모](./assets/demo.gif)
 
 ## 왜 tmux-agent-pulse인가?
 
@@ -63,7 +68,9 @@ run-shell ~/.tmux/plugins/tmux-agent-pulse/agent-pulse.tmux
 | `AGENT_PULSE_DONE_THRESHOLD` | `3` | 완료 판정에 필요한 연속 미변경 횟수 |
 | `AGENT_PULSE_ICON_RESPONDING` | `💬` | 응답 중 아이콘 |
 | `AGENT_PULSE_ICON_DONE` | `✅` | 완료 아이콘 |
+| `AGENT_PULSE_ICON_WAITING` | `❓` | 대기 중 아이콘 (권한 요청) |
 | `AGENT_PULSE_CLI_PATTERN` | `claude\|codex\|gemini` | CLI 도구 감지용 정규식 패턴 |
+| `AGENT_PULSE_WAITING_PATTERN` | `Do you want to allow` | 권한 요청 감지용 정규식 패턴 |
 
 `~/.tmux.conf` 설정 예시:
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ AI CLI status notifications for tmux. Supports Claude Code, Codex CLI, and Gemin
 Shows status icons on tmux window names when AI CLI tools are active:
 
 - **💬** — AI is responding (output detected for 2.5s+)
+- **❓** — AI is waiting for user input (permission prompt detected)
 - **✅** — AI finished responding (output stopped)
 - Icons auto-clear when you switch to the window
+
+## Demo
+
+![tmux-agent-pulse demo](./assets/demo.gif)
 
 ## Why tmux-agent-pulse?
 
@@ -63,7 +68,9 @@ Optional environment variables (set before the plugin loads):
 | `AGENT_PULSE_DONE_THRESHOLD` | `3` | Consecutive unchanged polls needed to detect done |
 | `AGENT_PULSE_ICON_RESPONDING` | `💬` | Icon for responding state |
 | `AGENT_PULSE_ICON_DONE` | `✅` | Icon for done state |
+| `AGENT_PULSE_ICON_WAITING` | `❓` | Icon for waiting (permission prompt) state |
 | `AGENT_PULSE_CLI_PATTERN` | `claude\|codex\|gemini` | Regex pattern to match CLI tool names in process args |
+| `AGENT_PULSE_WAITING_PATTERN` | `Do you want to allow` | Regex pattern to detect permission prompts in pane output |
 
 Example in `~/.tmux.conf`:
 

--- a/scripts/daemon.sh
+++ b/scripts/daemon.sh
@@ -3,6 +3,7 @@
 # Detects AI CLI tools (Claude Code, Codex CLI, Gemini CLI) by inspecting child processes
 # and shows status icons on window names:
 #   💬 = responding (sustained output for 2.5s+)
+#   ❓ = waiting (output stopped + permission prompt detected)
 #   ✅ = done (output stopped after responding)
 
 SNAPSHOT_DIR="/tmp/agent-pulse-snapshots"
@@ -16,6 +17,8 @@ THRESHOLD="${AGENT_PULSE_THRESHOLD:-5}"
 DONE_THRESHOLD="${AGENT_PULSE_DONE_THRESHOLD:-3}"
 ICON_RESPONDING="${AGENT_PULSE_ICON_RESPONDING:-💬}"
 ICON_DONE="${AGENT_PULSE_ICON_DONE:-✅}"
+ICON_WAITING="${AGENT_PULSE_ICON_WAITING:-❓}"
+WAITING_PATTERN="${AGENT_PULSE_WAITING_PATTERN:-Do you want to allow}"
 
 # md5 command differs between macOS and Linux
 if command -v md5 &>/dev/null; then
@@ -37,10 +40,10 @@ while true; do
     STATE_FILE="$STATE_DIR/$PANE_KEY"
     STATE=$(cat "$STATE_FILE" 2>/dev/null || echo "idle")
 
-    # User is viewing this window + done state → clear done icon (before CLI check)
-    if [ "$STATE" = "done" ] && echo "$VISIBLE" | grep -qFx "$TARGET"; then
+    # User is viewing this window + done/waiting state → clear icon (before CLI check)
+    if ([ "$STATE" = "done" ] || [ "$STATE" = "waiting" ]) && echo "$VISIBLE" | grep -qFx "$TARGET"; then
       WINDOW_NAME=$(tmux display-message -t "$TARGET" -p '#{window_name}' 2>/dev/null) || continue
-      CLEAN_NAME=$(echo "$WINDOW_NAME" | sed -E "s/^($ICON_DONE|$ICON_RESPONDING) //")
+      CLEAN_NAME=$(echo "$WINDOW_NAME" | sed -E "s/^($ICON_DONE|$ICON_RESPONDING|$ICON_WAITING) //")
       [ "$WINDOW_NAME" != "$CLEAN_NAME" ] && tmux rename-window -t "$TARGET" "$CLEAN_NAME" 2>/dev/null
       echo "idle" > "$STATE_FILE"
       echo "0" > "$COUNTER_DIR/$PANE_KEY"
@@ -59,7 +62,7 @@ while true; do
     DONE_COUNT=$(cat "$DONE_COUNT_FILE" 2>/dev/null || echo "0")
 
     WINDOW_NAME=$(tmux display-message -t "$TARGET" -p '#{window_name}' 2>/dev/null) || continue
-    CLEAN_NAME=$(echo "$WINDOW_NAME" | sed -E "s/^($ICON_DONE|$ICON_RESPONDING) //")
+    CLEAN_NAME=$(echo "$WINDOW_NAME" | sed -E "s/^($ICON_DONE|$ICON_RESPONDING|$ICON_WAITING) //")
 
     # Compare pane output snapshot
     CURRENT=$(tmux capture-pane -t "$PANE_ID" -p -S -3 2>/dev/null | eval "$MD5_CMD")
@@ -78,12 +81,21 @@ while true; do
         [ "$WINDOW_NAME" != "$ICON_RESPONDING $CLEAN_NAME" ] && tmux rename-window -t "$TARGET" "$ICON_RESPONDING $CLEAN_NAME" 2>/dev/null
       fi
     else
-      if [ "$STATE" = "responding" ]; then
+      if [ "$STATE" = "responding" ] || [ "$STATE" = "waiting" ]; then
         DONE_COUNT=$((DONE_COUNT + 1))
         echo "$DONE_COUNT" > "$DONE_COUNT_FILE"
         if [ "$DONE_COUNT" -ge "$DONE_THRESHOLD" ]; then
-          echo "done" > "$STATE_FILE"
-          tmux rename-window -t "$TARGET" "$ICON_DONE $CLEAN_NAME" 2>/dev/null
+          # Check if pane is showing a permission prompt
+          PANE_TEXT=$(tmux capture-pane -t "$PANE_ID" -p -S -10 2>/dev/null)
+          if echo "$PANE_TEXT" | grep -qE "$WAITING_PATTERN"; then
+            if [ "$STATE" != "waiting" ]; then
+              echo "waiting" > "$STATE_FILE"
+              tmux rename-window -t "$TARGET" "$ICON_WAITING $CLEAN_NAME" 2>/dev/null
+            fi
+          else
+            echo "done" > "$STATE_FILE"
+            tmux rename-window -t "$TARGET" "$ICON_DONE $CLEAN_NAME" 2>/dev/null
+          fi
           echo "0" > "$COUNT_FILE"
         fi
       else


### PR DESCRIPTION
## Summary
- AI CLI가 권한 승인을 요청하는 상태를 별도 아이콘(❓)으로 표시
- `AGENT_PULSE_ICON_WAITING`, `AGENT_PULSE_WAITING_PATTERN` 환경변수 추가

## Changes
- `responding` → 출력 멈춤 시 pane 마지막 10줄에서 권한 요청 패턴 감지
- 패턴 매칭 시 `waiting`(❓), 미매칭 시 `done`(✅)으로 분기
- `waiting` 상태도 `done`과 동일하게 윈도우 포커스 시 `idle`로 초기화

## Test plan
- [ ] Claude Code 권한 요청 시 ❓ 아이콘 표시 확인
- [ ] 권한 승인 후 💬로 복귀 확인
- [ ] 응답 완료 시 기존대로 ✅ 표시 확인

Resolved #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)