### PR TITLE
데모 GIF 추가 및 .gitignore 업데이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.log
 /tmp/
+.worklog/


### PR DESCRIPTION
Resolved #17

## 개요🔎

README에서 플러그인 동작을 바로 확인할 수 있도록 데모 GIF를 추가하고, .worklog 디렉토리를 .gitignore에 추가한다.

## 작업사항✍🏻

-   데모 GIF 파일 추가 (`assets/demo.gif`)
-   `.gitignore`에 `.worklog/` 추가

## 주의사항❗️

-   데모 GIF 파일 크기가 약 13MB로 다소 큼